### PR TITLE
Passing options hash to setter functions

### DIFF
--- a/backbone.getters.setters.js
+++ b/backbone.getters.setters.js
@@ -24,7 +24,7 @@ Backbone.GSModel = Backbone.Model.extend({
 		// Go over all the set attributes and call the setter if available
 		for (attr in attrs) {
 			if (_.isFunction(this.setters[attr])) {
-				attrs[attr] = this.setters[attr].call(this, attrs[attr]);
+				attrs[attr] = this.setters[attr].call(this, attrs[attr], options);
 			}
 		}
 


### PR DESCRIPTION
I've found this useful, especially if you have reason to use custom options keys or want to call `set` for another attribute within a setter function and need the options to apply for that attribute as well.
