### PR TITLE
Alway pass the options object to the setter

### DIFF
--- a/backbone.getters.setters.js
+++ b/backbone.getters.setters.js
@@ -5,7 +5,7 @@ Backbone.GSModel = Backbone.Model.extend({
 		if (_.isFunction(this.getters[attr])) {
 			return this.getters[attr].call(this);
 		}
-		
+
 		return Backbone.Model.prototype.get.call(this, attr);
 	},
 
@@ -21,6 +21,10 @@ Backbone.GSModel = Backbone.Model.extend({
 			attrs[key] = value;
 		}
 
+		// always pass an options hash around. This allows modifying
+		// the options inside the setter
+		options = options || {};
+
 		// Go over all the set attributes and call the setter if available
 		for (attr in attrs) {
 			if (_.isFunction(this.setters[attr])) {
@@ -30,9 +34,9 @@ Backbone.GSModel = Backbone.Model.extend({
 
 		return Backbone.Model.prototype.set.call(this, attrs, options);
 	},
-	
+
 	getters: {},
-	
+
 	setters: {}
-	
+
 });


### PR DESCRIPTION
This PR creates an options object if none was created by the user. This
allows for modification of options inside the setter as the object is
passed by reference.

This behaviour mirrors `Backbone.Model#set()`:
https://github.com/documentcloud/backbone/blob/master/backbone.js#L322

My specific use case is that I want to always validate the setting of a specific attribute. However, with Backbone 0.9.10, you need to pass `{ validate: true }` to `Backbone.Model#set()` in order to force validation. 
This allows the user to create a setter that makes sure the options they want are always set.
